### PR TITLE
Deprecate Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # bazo-keypairgen
+
+This repository is deprecated. Use [bazo-miner](https://github.com/bazo-blockchain/bazo-miner) to generate a keypair.
+
+```bash
+./bazo-miner generate keyfile.txt
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # bazo-keypairgen
 
 This repository is deprecated. Use [bazo-miner](https://github.com/bazo-blockchain/bazo-miner) to generate a keypair.
-
-```bash
-./bazo-miner generate keyfile.txt
-```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # bazo-keypairgen
 
-This repository is deprecated. Use [bazo-miner](https://github.com/bazo-blockchain/bazo-miner) to generate a keypair.
+This repository is deprecated. Use [bazo-miner](https://github.com/bazo-blockchain/bazo-miner) to generate a wallet keypair.


### PR DESCRIPTION
Hey *Bazo-People* 👋 

Since I integrated the generate keypair function into the Bazo miner (see PR [#24](https://github.com/bazo-blockchain/bazo-miner/pull/24)), this repository can now be considered deprecated.

```bash
R.I.P. ☠️ 
bazo-keypairgen
2018 - 2018
```